### PR TITLE
ABF-3418: Add script-src-elem, script-src-attr, style-src-elem and style-src-attr CSP directives

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -186,6 +186,38 @@ class Builder
     }
 
     /**
+     * @param array $script_src_elem
+     */
+    public function setScriptSrcElem(array $script_src_elem = [])
+    {
+        $this->policy->script_src_elem = $script_src_elem;
+    }
+
+    /**
+     * @param string $script_src_elem
+     */
+    public function addScriptSrcElem($script_src_elem)
+    {
+        $this->policy->script_src_elem[] = $script_src_elem;
+    }
+
+    /**
+     * @param array $script_src_attr
+     */
+    public function setScriptSrcAttr(array $script_src_attr = [])
+    {
+        $this->policy->script_src_attr = $script_src_attr;
+    }
+
+    /**
+     * @param string $script_src_attr
+     */
+    public function addScriptSrcAttr($script_src_attr)
+    {
+        $this->policy->script_src_attr[] = $script_src_attr;
+    }
+
+    /**
      * @param array $style_src
      */
     public function setStyleSrc(array $style_src = [])
@@ -199,6 +231,38 @@ class Builder
     public function addStyleSrc($style_src)
     {
         $this->policy->style_src[] = $style_src;
+    }
+
+    /**
+     * @param array $style_src_elem
+     */
+    public function setStyleSrcElem(array $style_src_elem = [])
+    {
+        $this->policy->style_src_elem = $style_src_elem;
+    }
+
+    /**
+     * @param string $style_src_elem
+     */
+    public function addStyleSrcElem($style_src_elem)
+    {
+        $this->policy->style_src_elem[] = $style_src_elem;
+    }
+
+    /**
+     * @param array $style_src_attr
+     */
+    public function setStyleSrcAttr(array $style_src_attr = [])
+    {
+        $this->policy->style_src_attr = $style_src_attr;
+    }
+
+    /**
+     * @param string $style_src_attr
+     */
+    public function addStyleSrcAttr($style_src_attr)
+    {
+        $this->policy->style_src_attr[] = $style_src_attr;
     }
 
     /**

--- a/src/Policy.php
+++ b/src/Policy.php
@@ -41,7 +41,11 @@ class Policy
     public $media_src = [];
     public $object_src = [];
     public $script_src = [];
+    public $script_src_elem = [];
+    public $script_src_attr = [];
     public $style_src = [];
+    public $style_src_elem = [];
+    public $style_src_attr = [];
     public $worker_src = [];
 
     /* Document directives */

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -213,6 +213,42 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(self::AN_ARRAY_WITH_A_URI, $this->policy->script_src);
     }
 
+    public function test_setScriptSrcElem_replacesPolicyScriptSrcElem()
+    {
+        $this->policy->script_src_elem = self::AN_ARRAY;
+
+        $this->builder->setScriptSrcElem(self::REPLACEMENT_ARRAY);
+
+        $this->assertSame(self::REPLACEMENT_ARRAY, $this->policy->script_src_elem);
+    }
+
+    public function test_addScriptSrcElem_addsPolicyScriptSrcElem()
+    {
+        $this->policy->script_src_elem = self::AN_ARRAY;
+
+        $this->builder->addScriptSrcElem(self::A_URI);
+
+        $this->assertSame(self::AN_ARRAY_WITH_A_URI, $this->policy->script_src_elem);
+    }
+
+    public function test_setScriptSrcAttr_replacesPolicyScriptSrcAttr()
+    {
+        $this->policy->script_src_attr = self::AN_ARRAY;
+
+        $this->builder->setScriptSrcAttr(self::REPLACEMENT_ARRAY);
+
+        $this->assertSame(self::REPLACEMENT_ARRAY, $this->policy->script_src_attr);
+    }
+
+    public function test_addScriptSrcAttr_addsPolicyScriptSrcAttr()
+    {
+        $this->policy->script_src_attr = self::AN_ARRAY;
+
+        $this->builder->addScriptSrcAttr(self::A_URI);
+
+        $this->assertSame(self::AN_ARRAY_WITH_A_URI, $this->policy->script_src_attr);
+    }
+
     public function test_setStyleSrc_replacesPolicyStyleSrc()
     {
         $this->policy->style_src = self::AN_ARRAY;
@@ -229,6 +265,42 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->builder->addStyleSrc(self::A_URI);
 
         $this->assertSame(self::AN_ARRAY_WITH_A_URI, $this->policy->style_src);
+    }
+
+    public function test_setStyleSrcElem_replacesPolicyStyleSrcElem()
+    {
+        $this->policy->style_src_elem = self::AN_ARRAY;
+
+        $this->builder->setStyleSrcElem(self::REPLACEMENT_ARRAY);
+
+        $this->assertSame(self::REPLACEMENT_ARRAY, $this->policy->style_src_elem);
+    }
+
+    public function test_addStyleSrcElem_addsPolicyStyleSrcElem()
+    {
+        $this->policy->style_src_elem = self::AN_ARRAY;
+
+        $this->builder->addStyleSrcElem(self::A_URI);
+
+        $this->assertSame(self::AN_ARRAY_WITH_A_URI, $this->policy->style_src_elem);
+    }
+
+    public function test_setStyleSrcAttr_replacesPolicyStyleSrcAttr()
+    {
+        $this->policy->style_src_attr = self::AN_ARRAY;
+
+        $this->builder->setStyleSrcAttr(self::REPLACEMENT_ARRAY);
+
+        $this->assertSame(self::REPLACEMENT_ARRAY, $this->policy->style_src_attr);
+    }
+
+    public function test_addStyleSrcAttr_addsPolicyStyleSrcAttr()
+    {
+        $this->policy->style_src_attr = self::AN_ARRAY;
+
+        $this->builder->addStyleSrcAttr(self::A_URI);
+
+        $this->assertSame(self::AN_ARRAY_WITH_A_URI, $this->policy->style_src_attr);
     }
 
     public function test_setWorkerSrc_replacesPolicyWorkerSrc()


### PR DESCRIPTION
Chrome a ajouté 4 nouvelles directives dans ses CSP,
Voir:
https://www.chromestatus.com/feature/5141352765456384
https://w3c.github.io/webappsec-csp/#directive-script-src-attr

- script-src-elem
- script-src-attr
- style-src-elem
- style-src-attr

J'aimerais donc les ajouter à notre CSP builder.
